### PR TITLE
make it support from rails 4.0.0

### DIFF
--- a/activesupport-current_attributes.gemspec
+++ b/activesupport-current_attributes.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["MIT-LICENSE", "README.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport",  ">= 4.2.0"
+  spec.add_runtime_dependency "activesupport",  ">= 4.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Updated runtime dependency `activesupport` version to `4.0.0` from`4.2.0` to make it work with rails 4.0.0 too. 